### PR TITLE
print headers to stderr when using stdout output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.2.1
+output device name and command to stderr when using stdout output. This is to allow usage of jq on the message body.
+
+## 0.2.0
+added flags to define device from CLI
+
 ## 0.1.1
 Added windows build
 

--- a/commando/respwriter.go
+++ b/commando/respwriter.go
@@ -40,11 +40,12 @@ func (app *appCfg) newResponseWriter(f string) responseWriter {
 type consoleWriter struct{}
 
 func (w *consoleWriter) WriteResponse(r *base.MultiResponse, name string, d *device, appCfg *appCfg) error {
-	color.Green("\n**************************\n%s\n**************************\n", name)
+	c := color.New(color.FgGreen)
+	c.Fprintf(os.Stderr, "\n**************************\n%s\n**************************\n", name)
 
 	for idx, cmd := range d.SendCommands {
 		c := color.New(color.Bold)
-		c.Printf("\n-- %s:\n", cmd)
+		c.Fprintf(os.Stderr, "\n-- %s:\n", cmd)
 
 		if r.Responses[idx].Failed {
 			color.Set(color.FgRed)


### PR DESCRIPTION
to allow for jq processing