### PR TITLE
added inventory defaults ++ extras

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vscode
 outputs*
 dist
 cmdo

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 outputs*
 dist
 cmdo
+private

--- a/commando/cmdo.go
+++ b/commando/cmdo.go
@@ -53,8 +53,8 @@ const (
 )
 
 type inventory struct {
-	Credentials map[string]*credentials `yaml:",omitempty"`
-	Transports  map[string]*transports  `yaml:",omitempty"`
+	Credentials map[string]*credentials `yaml:"credentials,omitempty"`
+	Transports  map[string]*transports  `yaml:"transports,omitempty"`
 	Devices     map[string]*device      `yaml:"devices,omitempty"`
 }
 

--- a/commando/cmdo.go
+++ b/commando/cmdo.go
@@ -39,54 +39,60 @@ var (
 	errNoUsernameDefined = errors.New("username was not provided. Use --username | -u to set it")
 	errNoPasswordDefined = errors.New("password was not provided. Use --passoword | -p to set it")
 	errNoCommandsDefined = errors.New("commands were not provided. Use --commands | -c to set a `::` delimited list of commands to run")
-	errInvalidTransport  = errors.New("invalid transport name provided in inventory. Transport should be one of: [standard, system]")
+
+	errInvalidCredentialsName = errors.New("invalid credentials name provided for host")
+	errInvalidTransportsName  = errors.New("invalid transport name provided for host")
+
+	errInvalidTransport = errors.New("invalid transport name provided in inventory. Transport should be one of: [standard, system]")
 )
 
 const (
 	fileOutput   = "file"
 	stdoutOutput = "stdout"
+	defaultName  = "default"
 )
 
 type inventory struct {
-	Devices  map[string]*device `yaml:"devices,omitempty"`
-	Defaults *defaults          `yaml:",omitempty"`
+	Credentials map[string]*credentials `yaml:",omitempty"`
+	Transports  map[string]*transports  `yaml:",omitempty"`
+	Devices     map[string]*device      `yaml:"devices,omitempty"`
 }
 
 type device struct {
 	Platform     string   `yaml:"platform,omitempty"`
 	Address      string   `yaml:"address,omitempty"`
-	Username     string   `yaml:"username,omitempty"`
-	Password     string   `yaml:"password,omitempty"`
+	Credentials  string   `yaml:"credentials,omitempty"`
+	Transport    string   `yaml:"transport,omitempty"`
 	SendCommands []string `yaml:"send-commands,omitempty"`
-	Extras       *extras  `yaml:",omitempty"`
 }
 
-type extras struct {
-	Port              int    `yaml:"port,omitempty"`
+type credentials struct {
+	Username          string `yaml:"username,omitempty"`
+	Password          string `yaml:"password,omitempty"`
 	SecondaryPassword string `yaml:"secondary-password,omitempty"`
-	SSHConfigFile     string `yaml:"ssh-config-file,omitempty"`
-	StrictKey         bool   `yaml:"strict-key,omitempty"`
-	TransportType     string `yaml:"transport,omitempty"`
+	PrivateKey        string `yaml:"private-key,omitempty"`
 }
 
-type defaults struct {
-	Username string  `yaml:"username,omitempty"`
-	Password string  `yaml:"password,omitempty"`
-	Extras   *extras `yaml:",omitempty"`
+type transports struct {
+	Port          int    `yaml:"port,omitempty"`
+	StrictKey     bool   `yaml:"strict-key,omitempty"`
+	SSHConfigFile string `yaml:"ssh-config-file,omitempty"`
+	TransportType string `yaml:"transport,omitempty"`
 }
 
 type appCfg struct {
-	inventory         string    // path to inventory file
-	inventoryDefaults *defaults // loaded defaults settings
-	output            string    // output mode
-	timestamp         bool      // append timestamp to output dir
-	outDir            string    // output directory path
-	devFilter         string    // pattern
-	platform          string    // platform name
-	address           string    // device address
-	username          string    // ssh username
-	password          string    // ssh password
-	commands          string    // commands to send
+	inventory   string                  // path to inventory file
+	credentials map[string]*credentials // credentials loaded from inventory
+	transports  map[string]*transports  // transports loaded from inventory
+	output      string                  // output mode
+	timestamp   bool                    // append timestamp to output dir
+	outDir      string                  // output directory path
+	devFilter   string                  // pattern
+	platform    string                  // platform name
+	address     string                  // device address
+	username    string                  // ssh username
+	password    string                  // ssh password
+	commands    string                  // commands to send
 }
 
 // run runs the commando.
@@ -141,80 +147,95 @@ func (app *appCfg) validTransport(t string) bool {
 	}
 }
 
-// loadOptionsExtras load the extras from the root of inventory or a specific device.
-func (app *appCfg) loadOptionsExtras(e *extras, o []base.Option) ([]base.Option, error) {
-	if e.Port != 0 {
-		o = append(o, base.WithPort(e.Port))
+func (app *appCfg) loadCredentials(o []base.Option, c string) ([]base.Option, error) {
+	creds, ok := app.credentials[c]
+	if !ok {
+		return o, errInvalidCredentialsName
 	}
 
-	if e.SecondaryPassword != "" {
-		o = append(o, base.WithAuthSecondary(e.SecondaryPassword))
+	if creds.Username != "" {
+		o = append(o, base.WithAuthUsername(creds.Username))
 	}
 
-	if e.SSHConfigFile != "" {
-		o = append(o, base.WithSSHConfigFile(e.SSHConfigFile))
+	if creds.Password != "" {
+		o = append(o, base.WithAuthPassword(creds.Password))
 	}
 
-	if e.StrictKey {
-		o = append(o, base.WithAuthStrictKey(e.StrictKey))
+	if creds.SecondaryPassword != "" {
+		o = append(o, base.WithAuthSecondary(creds.SecondaryPassword))
 	}
 
-	if e.TransportType != "" {
-		if !app.validTransport(e.TransportType) {
-			return nil, errInvalidTransport
-		}
-
-		o = append(o, base.WithPort(e.Port))
+	if creds.PrivateKey != "" {
+		o = append(o, base.WithAuthPrivateKey(creds.PrivateKey))
 	}
 
 	return o, nil
 }
 
-func (app *appCfg) loadOptionsDefaults(o []base.Option) ([]base.Option, error) {
-	// load defaults first, if there are more specific settings they will come after and
-	// override the defaults, this way we don't need to think about merging things.
-	var err error
+func (app *appCfg) loadTransport(o []base.Option, t string) ([]base.Option, error) {
+	// default to strict key false and standard transport, so load those into options first
+	o = append(o, base.WithTransportType(transport.StandardTransportName), base.WithAuthStrictKey(false))
 
-	if app.inventoryDefaults.Username != "" {
-		o = append(o, base.WithAuthUsername(app.inventoryDefaults.Username))
+	transp, ok := app.transports[t]
+	if !ok {
+		if t == defaultName {
+			// default can not exist in the inventory, we already set the default settings above
+			return o, nil
+		}
+
+		return o, errInvalidTransportsName
 	}
 
-	if app.inventoryDefaults.Password != "" {
-		o = append(o, base.WithAuthUsername(app.inventoryDefaults.Password))
+	if transp.Port != 0 {
+		o = append(o, base.WithPort(transp.Port))
 	}
 
-	if app.inventoryDefaults.Extras != nil {
-		o, err = app.loadOptionsExtras(app.inventoryDefaults.Extras, o)
+	if transp.StrictKey {
+		o = append(o, base.WithAuthStrictKey(transp.StrictKey))
 	}
 
-	return o, err
+	if transp.SSHConfigFile != "" {
+		o = append(o, base.WithSSHConfigFile(transp.SSHConfigFile))
+	}
+
+	if transp.TransportType != "" {
+		if !app.validTransport(transp.TransportType) {
+			return nil, errInvalidTransport
+		}
+
+		o = append(o, base.WithTransportType(transp.TransportType))
+	}
+
+	return o, nil
 }
 
 // loadOptions loads options from the provided inventory.
 func (app *appCfg) loadOptions(d *device) ([]base.Option, error) {
 	var o []base.Option
 
-	// defaulting to auth strict key false
-	o = append(o, base.WithAuthStrictKey(false))
-
 	var err error
 
-	if app.inventoryDefaults != nil {
-		o, err = app.loadOptionsDefaults(o)
-		if err != nil {
-			return o, err
-		}
+	c := defaultName
+
+	if d.Credentials != "" {
+		c = d.Credentials
 	}
 
-	if d.Username != "" {
-		o = append(o, base.WithAuthUsername(d.Username))
+	o, err = app.loadCredentials(o, c)
+	if err != nil {
+		return o, err
 	}
 
-	if d.Password != "" {
-		o = append(o, base.WithAuthPassword(d.Password))
+	t := defaultName
+
+	if d.Transport != "" {
+		t = d.Transport
 	}
 
-	o, err = app.loadOptionsExtras(d.Extras, o)
+	o, err = app.loadTransport(o, t)
+	if err != nil {
+		return o, err
+	}
 
 	return o, err
 }
@@ -249,18 +270,24 @@ func (app *appCfg) runCommands(
 
 	if err != nil {
 		log.Errorf("failed to create driver for device %s; error: %+v\n", err, name)
+		rCh <- nil
+
 		return
 	}
 
 	err = driver.Open()
 	if err != nil {
 		log.Errorf("failed to open connection to device %s; error: %+v\n", err, name)
+		rCh <- nil
+
 		return
 	}
 
 	r, err := driver.SendCommands(d.SendCommands)
 	if err != nil {
 		log.Errorf("failed to send commands to device %s; error: %+v\n", err, name)
+		rCh <- nil
+
 		return
 	}
 
@@ -275,7 +302,7 @@ func (app *appCfg) outputResult(
 	r *base.MultiResponse) {
 	defer wg.Done()
 
-	if err := rw.WriteResponse(r, name, d, app); err != nil {
+	if err := rw.WriteResponse(r, name, d); err != nil {
 		log.Errorf("error while writing the response: %v", err)
 	}
 }
@@ -312,7 +339,8 @@ func (app *appCfg) loadInventoryFromYAML(i *inventory) error {
 		return errNoDevices
 	}
 
-	app.inventoryDefaults = i.Defaults
+	app.credentials = i.Credentials
+	app.transports = i.Transports
 
 	return nil
 }
@@ -341,8 +369,6 @@ func (app *appCfg) loadInventoryFromFlags(i *inventory) error {
 	i.Devices[app.address] = &device{
 		Platform:     app.platform,
 		Address:      app.address,
-		Username:     app.username,
-		Password:     app.password,
 		SendCommands: cmds,
 	}
 

--- a/commando/cmdo.go
+++ b/commando/cmdo.go
@@ -250,7 +250,7 @@ func (app *appCfg) runCommands(
 
 	o, err := app.loadOptions(d)
 	if err != nil {
-		log.Errorf("invalid transport type provided %s; error: %+v\n", err, name)
+		log.Errorf("failed to load credentials or transport options for %s; error: %+v\n", name, err)
 		return
 	}
 

--- a/commando/respwriter.go
+++ b/commando/respwriter.go
@@ -91,7 +91,7 @@ func (w *fileWriter) WriteResponse(r *base.MultiResponse, name string, d *device
 		c := sanitizeCmd(cmd)
 
 		rb := []byte(r.Responses[idx].Result)
-		if err := ioutil.WriteFile(path.Join(outDir, c), rb, filePermissions); err != nil { //nolint:gosec
+		if err := ioutil.WriteFile(path.Join(outDir, c), rb, filePermissions); err != nil {
 			return err
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/fatih/color v1.12.0
-	github.com/scrapli/scrapligo v0.0.0-20210602192414-6dd77b8af3c2
+	github.com/scrapli/scrapligo v0.0.0-20210704164516-6c3b4e74cfad
 	github.com/sirupsen/logrus v1.8.1
 	github.com/srl-labs/srlinux-scrapli v0.0.0-20210601201111-9eed8d440381
 	github.com/urfave/cli/v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,12 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/scrapli/scrapligo v0.0.0-20210601185115-acff0f312680/go.mod h1:itZE+qsyMvCMnxccsxMX4ATFqVLDIG/Mw4po4msqwpo=
 github.com/scrapli/scrapligo v0.0.0-20210602192414-6dd77b8af3c2 h1:tUOvIzMIJa9pbqKWTWx2OJi8JxF5AwgUGGWkMkSughM=
 github.com/scrapli/scrapligo v0.0.0-20210602192414-6dd77b8af3c2/go.mod h1:itZE+qsyMvCMnxccsxMX4ATFqVLDIG/Mw4po4msqwpo=
+github.com/scrapli/scrapligo v0.0.0-20210704164516-6c3b4e74cfad h1:eb+6BSk5gTJ3rsQ1CfZGfMsoxvo7ZYwKlCTszU1CtJs=
+github.com/scrapli/scrapligo v0.0.0-20210704164516-6c3b4e74cfad/go.mod h1:+csimZHh80jQXjdDdHmAIKCwiXPZvXQ7ZgKEQWmFpK8=
 github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
+github.com/sirikothe/gotextfsm v1.0.0 h1:4kKwbUziG9G+31PfLY+vI3FzYK/kcByh4ndT3NyPMkc=
+github.com/sirikothe/gotextfsm v1.0.0/go.mod h1:CJYqpTg9u5VPCoD0VEl9E68prCIiWQD8m457k098DdQ=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/srl-labs/srlinux-scrapli v0.0.0-20210601201111-9eed8d440381 h1:CMi5adZCXpbLtn1KLCj2sXtOcCFvmUzPzTR6Stf3DVU=

--- a/inventory.yml
+++ b/inventory.yml
@@ -1,25 +1,42 @@
+credentials:
+  default:
+    username: admin
+    password: admin
+  eos:
+    username: commando
+    password: commando
+    secondary-password: supercommando
+
+transports:
+  default: {}
+  # default has the following default settings
+  # port: 22
+  # strict-key: false
+  # transport-type: standard
+  #
+  # optional settings
+  # ssh-config-file: /your/ssh/config/file
+  eos:
+    transport-type: system
+
 devices:
   sros:
     platform: nokia_sros
     address: clab-scrapli-sros
-    username: admin
-    password: admin
     send-commands:
       - show version
       - show router interface
   eos:
     platform: arista_eos
     address: clab-scrapli-ceos
-    username: admin
-    password: admin
+    credentials: eos
+    transport: eos
     send-commands:
       - show version
       - show uptime
   srlinux:
     platform: nokia_srlinux
     address: clab-scrapli-srlinux
-    username: admin
-    password: admin
     send-commands:
       - show version
       - show network-instance interfaces


### PR DESCRIPTION
Sorry for PR without checking if you're even interested in this -- was just playing about with commando and had this so figured I'd raise this just in case you were interested!

TL;DR -- added defaults and "extras" to inventory yaml.

Defaults: fairly self explanatory -- figured rather than having to have username/password entered for every device having a default setting would be cool. The implementation is pretty basic -- just load a slice of options with the defaults coming first -- that way any device specific settings override the defaults.

Extras: could do without the "extras" parent, but basically its just "extra" stuff... hence the name. Things that folks probably wouldn't mess with too often -- port, auth strict key (I left `false` as the default, but now users can turn it on if they want), transport type (you know I love me the system transport! though this of course could break for windows users), ssh config file, and the secondary password (so we can deal with "enable" passwords).


Carl 