### PR TITLE
added support for config snippets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode
+.idea
 outputs*
 dist
 cmdo

--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@
 [![Github all releases](https://img.shields.io/github/downloads/hellt/cmdo/total.svg?style=flat-square&color=424f35&labelColor=bec8d2)](https://github.com/hellt/cmdo/releases/)
 ---
 
-Commando is a tiny tool that enables users to collect command outputs from a single or a multiple networking devices defined in an inventory file.
+Commando is a tiny tool that enables users 
+* to collect command outputs from a single or a multiple networking devices defined in an inventory file
+* send file-based or string-based configs towards the devices defined in the inventory file
+
+all that with zero dependencies and a 1-click installation.
 
 [![asciicast](https://asciinema.org/a/417792.svg)](https://asciinema.org/a/417792)
 
@@ -157,13 +161,38 @@ devices:
     address: string
     credentials: string # optional reference to the defined credentials
     transport: string # optional reference to the defined transport options
+    send-commands-from-file: /path/to/file/with/show-commands.txt
     send-commands:
-        - cmd1
-        - cmd2
-        - cmdN
+      - cmd1
+      - cmd2
+      - cmdN
+    send-configs-from-file: /path/to/file/with/config-commands.txt
+    send-configs:
+      - cmd1
+      - cmdN
 ```
 
-`send-commands` list holds a list of commands which will be send towards a device. Check out the attached [example inventory](inventory.yml) file to a reference.
+`send-commands` list holds a list of non-configuration commands which will be send towards a device. A non configuration command is a command that doesn't require to have a configuration mode enabled on a device. A typical example is a `show <something>` command.  
+Outputs from each command of a `send-commands` list will be saved/printed.
+
+If you want to keep the commands in a separate file, then you can use `send-commands-from-file` element which takes a path to a said file. You can combine `send-commands` and `send-commands-from-file` in a single device.
+
+In contrast with `send-commands*` options, it is possible to tell `commando` to send configuration commands. For that we have the following configuration elements:
+
+* `send-configs` - takes a list of configuration commands and executes then without printing/saving any output the commands may return
+* `send-configs-from-file` - does the same, but the commands are kept in a file.
+
+Entering in the config mode is handled by commando, so your config commands doesn't need to have any `conf t` or `configure private` commands. Just remember to add the `commit` command if your device needs it.
+
+The order these options are processed in:
+
+1. send-configs-from-file
+2. send-configs
+3. send-commands-from-file
+4. send-commands
+
+
+Check out the attached [example inventory](inventory.yml) file for reference.
 
 ## Configuration options
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,17 @@ devices:
     send-configs:
       - cmd1
       - cmdN
+    cfg-operations:
+      # Note: cfg operations currently supported only on: arista_eos, cisco_iosxe,
+      # cisco_nxos, cisco_iosxr, juniper_junos
+      - type: load-config
+        replace: false
+        diff: true
+        commit: false
+        # Note: there is also a "config-from-file" option to load configurations from a file
+        config: "interface loopback1\ndescription tacocat"
+      - type: get-config
+        source: running
 ```
 
 `send-commands` list holds a list of non-configuration commands which will be send towards a device. A non configuration command is a command that doesn't require to have a configuration mode enabled on a device. A typical example is a `show <something>` command.  
@@ -186,10 +197,11 @@ Entering in the config mode is handled by commando, so your config commands does
 
 The order these options are processed in:
 
-1. send-configs-from-file
-2. send-configs
-3. send-commands-from-file
-4. send-commands
+1. "cfg" operations
+2. send-configs-from-file
+3. send-configs
+4. send-commands-from-file
+5. send-commands
 
 
 Check out the attached [example inventory](inventory.yml) file for reference.

--- a/commando/cmdo.go
+++ b/commando/cmdo.go
@@ -3,20 +3,13 @@ package commando
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
-	"regexp"
-	"strings"
-
 	"sync"
 
-	"github.com/scrapli/scrapligo/driver/base"
-	"github.com/scrapli/scrapligo/driver/core"
+	"github.com/scrapli/scrapligo/cfg"
+
 	"github.com/scrapli/scrapligo/driver/network"
-	"github.com/scrapli/scrapligo/transport"
 	log "github.com/sirupsen/logrus"
-	"github.com/srl-labs/srlinux-scrapli"
-	"gopkg.in/yaml.v2"
 )
 
 var (
@@ -34,16 +27,22 @@ var (
 	}
 
 	errNoDevices         = errors.New("no devices to send commands to")
-	errNoPlatformDefined = fmt.Errorf("platform is not set, use --platform | -k <platform> to set one of the supported platforms: %q",
-		supportedPlatforms)
+	errNoPlatformDefined = fmt.Errorf(
+		"platform is not set, use --platform | -k <platform> to set one of the supported platforms: %q",
+		supportedPlatforms,
+	)
 	errNoUsernameDefined = errors.New("username was not provided. Use --username | -u to set it")
 	errNoPasswordDefined = errors.New("password was not provided. Use --passoword | -p to set it")
-	errNoCommandsDefined = errors.New("commands were not provided. Use --commands | -c to set a `::` delimited list of commands to run")
+	errNoCommandsDefined = errors.New(
+		"commands were not provided. Use --commands | -c to set a `::` delimited list of commands to run",
+	)
 
 	errInvalidCredentialsName = errors.New("invalid credentials name provided for host")
 	errInvalidTransportsName  = errors.New("invalid transport name provided for host")
 
-	errInvalidTransport = errors.New("invalid transport name provided in inventory. Transport should be one of: [standard, system]")
+	errInvalidTransport = errors.New(
+		"invalid transport name provided in inventory. Transport should be one of: [standard, system]",
+	)
 )
 
 const (
@@ -59,14 +58,15 @@ type inventory struct {
 }
 
 type device struct {
-	Platform             string   `yaml:"platform,omitempty"`
-	Address              string   `yaml:"address,omitempty"`
-	Credentials          string   `yaml:"credentials,omitempty"`
-	Transport            string   `yaml:"transport,omitempty"`
-	SendCommands         []string `yaml:"send-commands,omitempty"`
-	SendCommandsFromFile string   `yaml:"send-commands-from-file,omitempty"`
-	SendConfigs          []string `yaml:"send-configs,omitempty"`
-	SendConfigsFromFile  string   `yaml:"send-configs-from-file,omitempty"`
+	Platform             string          `yaml:"platform,omitempty"`
+	Address              string          `yaml:"address,omitempty"`
+	Credentials          string          `yaml:"credentials,omitempty"`
+	Transport            string          `yaml:"transport,omitempty"`
+	SendCommands         []string        `yaml:"send-commands,omitempty"`
+	SendCommandsFromFile string          `yaml:"send-commands-from-file,omitempty"`
+	SendConfigs          []string        `yaml:"send-configs,omitempty"`
+	SendConfigsFromFile  string          `yaml:"send-configs-from-file,omitempty"`
+	CfgOperations        []*cfgOperation `yaml:"cfg-operations,omitempty"`
 }
 
 type credentials struct {
@@ -81,6 +81,16 @@ type transports struct {
 	StrictKey     bool   `yaml:"strict-key,omitempty"`
 	SSHConfigFile string `yaml:"ssh-config-file,omitempty"`
 	TransportType string `yaml:"transport,omitempty"`
+}
+
+type cfgOperation struct {
+	OperationType  string `yaml:"type,omitempty"`
+	Source         string `yaml:"source,omitempty"`
+	Config         string `yaml:"config,omitempty"`
+	ConfigFromFile string `yaml:"config-from-file,omitempty"`
+	Replace        bool   `yaml:"replace,omitempty"`
+	Diff           bool   `yaml:"diff,omitempty"`
+	Commit         bool   `yaml:"commit,omitempty"`
 }
 
 type appCfg struct {
@@ -113,7 +123,7 @@ func (app *appCfg) run() error {
 	}
 
 	rw := app.newResponseWriter(app.output)
-	rCh := make(chan []*base.MultiResponse)
+	rCh := make(chan []interface{})
 
 	if app.output == fileOutput {
 		log.SetOutput(os.Stderr)
@@ -124,7 +134,7 @@ func (app *appCfg) run() error {
 	wg.Add(len(i.Devices))
 
 	for n, d := range i.Devices {
-		go app.runCommands(n, d, rCh)
+		go app.runOperations(n, d, rCh)
 
 		resps := <-rCh
 		go app.outputResult(wg, rw, n, resps)
@@ -139,183 +149,150 @@ func (app *appCfg) run() error {
 	return nil
 }
 
-func (app *appCfg) validTransport(t string) bool {
-	switch t {
-	case transport.SystemTransportName:
-		return true
-	case transport.StandardTransportName:
-		return true
-	default:
-		return false
+func runCfgGetConfig(name string, c *cfg.Cfg, op *cfgOperation) (*cfg.Response, error) {
+	source := "running"
+	if op.Source != "" {
+		source = op.Source
 	}
+
+	r, err := c.GetConfig(source)
+	if err != nil {
+		log.Errorf("get-config operation failed for device %s; error: %+v\n", name, err)
+
+		return nil, err
+	}
+
+	return r, nil
 }
 
-func (app *appCfg) loadCredentials(o []base.Option, c string) ([]base.Option, error) {
-	creds, ok := app.credentials[c]
-	if !ok {
-		return o, errInvalidCredentialsName
-	}
+func runCfgLoadConfig(name string, c *cfg.Cfg, op *cfgOperation) ([]interface{}, error) {
+	var responses []interface{}
 
-	if creds.Username != "" {
-		o = append(o, base.WithAuthUsername(creds.Username))
-	}
-
-	if creds.Password != "" {
-		o = append(o, base.WithAuthPassword(creds.Password))
-	}
-
-	if creds.SecondaryPassword != "" {
-		o = append(o, base.WithAuthSecondary(creds.SecondaryPassword))
-	}
-
-	if creds.PrivateKey != "" {
-		o = append(o, base.WithAuthPrivateKey(creds.PrivateKey))
-	}
-
-	return o, nil
-}
-
-func (app *appCfg) loadTransport(o []base.Option, t string) ([]base.Option, error) {
-	// default to strict key false and standard transport, so load those into options first
-	o = append(o, base.WithTransportType(transport.StandardTransportName), base.WithAuthStrictKey(false))
-
-	transp, ok := app.transports[t]
-	if !ok {
-		if t == defaultName {
-			// default can not exist in the inventory, we already set the default settings above
-			return o, nil
-		}
-
-		return o, errInvalidTransportsName
-	}
-
-	if transp.Port != 0 {
-		o = append(o, base.WithPort(transp.Port))
-	}
-
-	if transp.StrictKey {
-		o = append(o, base.WithAuthStrictKey(transp.StrictKey))
-	}
-
-	if transp.SSHConfigFile != "" {
-		o = append(o, base.WithSSHConfigFile(transp.SSHConfigFile))
-	}
-
-	if transp.TransportType != "" {
-		if !app.validTransport(transp.TransportType) {
-			return nil, errInvalidTransport
-		}
-
-		o = append(o, base.WithTransportType(transp.TransportType))
-	}
-
-	return o, nil
-}
-
-// loadOptions loads options from the provided inventory.
-func (app *appCfg) loadOptions(d *device) ([]base.Option, error) {
-	var o []base.Option
+	var r *cfg.Response
 
 	var err error
 
-	c := defaultName
-
-	if d.Credentials != "" {
-		c = d.Credentials
+	if op.Config != "" {
+		_, err = c.LoadConfig(op.Config, op.Replace)
+	} else if op.ConfigFromFile != "" {
+		_, err = c.LoadConfigFromFile(op.ConfigFromFile, op.Replace)
 	}
 
-	o, err = app.loadCredentials(o, c)
 	if err != nil {
-		return o, err
+		log.Errorf("load-config operation failed for device %s; error: %+v\n", name, err)
+
+		return nil, err
 	}
 
-	t := defaultName
+	if op.Diff {
+		dr, diffErr := c.DiffConfig()
+		if diffErr != nil {
+			log.Errorf("diff-config operation failed for device %s; error: %+v\n", name, diffErr)
 
-	if d.Transport != "" {
-		t = d.Transport
+			return nil, diffErr
+		}
+
+		responses = append(responses, dr)
 	}
 
-	o, err = app.loadTransport(o, t)
-	if err != nil {
-		return o, err
+	if op.Commit {
+		r, err = c.CommitConfig()
+		if err != nil {
+			log.Errorf("commit-config operation failed for device %s; error: %+v\n", name, err)
+
+			return nil, err
+		}
+
+		responses = append(responses, r)
+	} else {
+		_, err = c.AbortConfig()
+		if err != nil {
+			log.Errorf("abort-config operation failed for device %s; error: %+v\n", name, err)
+
+			return nil, err
+		}
 	}
 
-	return o, err
+	return responses, nil
 }
 
-func (app *appCfg) runCommands(
-	name string,
-	d *device,
-	rCh chan<- []*base.MultiResponse) {
-	var driver *network.Driver
+func runCfg(name string, d *device, driver *network.Driver) ([]interface{}, error) {
+	if d.CfgOperations == nil {
+		return nil, nil
+	}
 
-	var err error
-
-	o, err := app.loadOptions(d)
+	c, err := cfg.NewCfgDriver(driver, d.Platform)
 	if err != nil {
-		log.Errorf("failed to load credentials or transport options for %s; error: %+v\n", name, err)
-		return
+		log.Errorf("failed to create cfg connection for device %s; error: %+v\n", name, err)
+
+		return nil, err
 	}
 
-	switch d.Platform {
-	case "nokia_srlinux":
-		driver, err = srlinux.NewSRLinuxDriver(
-			d.Address,
-			o...,
-		)
-	default:
-		driver, err = core.NewCoreDriver(
-			d.Address,
-			d.Platform,
-			o...,
-		)
-	}
-
+	err = c.Prepare()
 	if err != nil {
-		log.Errorf("failed to create driver for device %s; error: %+v\n", err, name)
-		rCh <- nil
+		log.Errorf("failed to prepare cfg session for device %s; error: %+v\n", name, err)
 
-		return
+		return nil, err
 	}
 
-	err = driver.Open()
-	if err != nil {
-		log.Errorf("failed to open connection to device %s; error: %+v\n", err, name)
-		rCh <- nil
+	var responses []interface{}
 
-		return
+	for _, op := range d.CfgOperations {
+		switch op.OperationType {
+		case "get-config":
+			r, opErr := runCfgGetConfig(name, c, op)
+			if opErr != nil {
+				return nil, opErr
+			}
+
+			responses = append(responses, r)
+		case "load-config":
+			r, opErr := runCfgLoadConfig(name, c, op)
+			if opErr != nil {
+				return nil, opErr
+			}
+
+			responses = append(responses, r...)
+		default:
+			log.Errorf("invalid operation type '%s' for device %s\n", op.OperationType, name)
+		}
 	}
 
-	var responses []*base.MultiResponse
+	return responses, nil
+}
 
+func runConfigs(name string, d *device, driver *network.Driver) error {
 	// when sending configs we do not print any responses, as typically configs do not produce any output
 	if d.SendConfigsFromFile != "" {
 		_, err := driver.SendConfigsFromFile(d.SendConfigsFromFile)
 		if err != nil {
-			log.Errorf("failed to send configs to device %s; error: %+v\n", err, name)
-			rCh <- nil
+			log.Errorf("failed to send configs to device %s; error: %+v\n", name, err)
 
-			return
+			return err
 		}
 	}
 
 	if len(d.SendConfigs) != 0 {
 		_, err := driver.SendConfigs(d.SendConfigs)
 		if err != nil {
-			log.Errorf("failed to send configs to device %s; error: %+v\n", err, name)
-			rCh <- nil
+			log.Errorf("failed to send configs to device %s; error: %+v\n", name, err)
 
-			return
+			return err
 		}
 	}
+
+	return nil
+}
+
+func runCommands(name string, d *device, driver *network.Driver) ([]interface{}, error) {
+	var responses []interface{}
 
 	if d.SendCommandsFromFile != "" {
 		r, err := driver.SendCommandsFromFile(d.SendCommandsFromFile)
 		if err != nil {
-			log.Errorf("failed to send commands to device %s; error: %+v\n", err, name)
-			rCh <- nil
+			log.Errorf("failed to send commands to device %s; error: %+v\n", name, err)
 
-			return
+			return nil, err
 		}
 
 		responses = append(responses, r)
@@ -324,14 +301,55 @@ func (app *appCfg) runCommands(
 	if len(d.SendCommands) != 0 {
 		r, err := driver.SendCommands(d.SendCommands)
 		if err != nil {
-			log.Errorf("failed to send commands to device %s; error: %+v\n", err, name)
-			rCh <- nil
+			log.Errorf("failed to send commands to device %s; error: %+v\n", name, err)
 
-			return
+			return nil, err
 		}
 
 		responses = append(responses, r)
 	}
+
+	return responses, nil
+}
+
+func (app *appCfg) runOperations(
+	name string,
+	d *device,
+	rCh chan<- []interface{}) {
+	driver, err := app.openCoreConn(name, d)
+	if err != nil {
+		rCh <- nil
+
+		return
+	}
+
+	var responses []interface{}
+
+	cfgResponses, err := runCfg(name, d, driver)
+	if err != nil {
+		rCh <- nil
+
+		return
+	}
+
+	responses = append(responses, cfgResponses...)
+
+	err = runConfigs(name, d, driver)
+	if err != nil {
+		rCh <- nil
+
+		return
+	}
+
+	cmdResponses, err := runCommands(name, d, driver)
+	if err != nil {
+		rCh <- nil
+
+		return
+	}
+
+	responses = append(responses, cmdResponses...)
+
 	rCh <- responses
 }
 
@@ -339,78 +357,10 @@ func (app *appCfg) outputResult(
 	wg *sync.WaitGroup,
 	rw responseWriter,
 	name string,
-	r []*base.MultiResponse) {
+	r []interface{}) {
 	defer wg.Done()
 
 	if err := rw.WriteResponse(r, name); err != nil {
 		log.Errorf("error while writing the response: %v", err)
 	}
-}
-
-// filterDevices will remove the devices which names do not match the passed filter.
-func filterDevices(i *inventory, f string) {
-	if f == "" {
-		return
-	}
-
-	fRe := regexp.MustCompile(f)
-
-	for n := range i.Devices {
-		if !fRe.Match([]byte(n)) {
-			delete(i.Devices, n)
-		}
-	}
-}
-
-func (app *appCfg) loadInventoryFromYAML(i *inventory) error {
-	yamlFile, err := ioutil.ReadFile(app.inventory)
-	if err != nil {
-		return err
-	}
-
-	err = yaml.UnmarshalStrict(yamlFile, i)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	filterDevices(i, app.devFilter)
-
-	if len(i.Devices) == 0 {
-		return errNoDevices
-	}
-
-	app.credentials = i.Credentials
-	app.transports = i.Transports
-
-	return nil
-}
-
-func (app *appCfg) loadInventoryFromFlags(i *inventory) error {
-	if app.platform == "" {
-		return errNoPlatformDefined
-	}
-
-	if app.username == "" {
-		return errNoUsernameDefined
-	}
-
-	if app.password == "" {
-		return errNoPasswordDefined
-	}
-
-	if app.commands == "" {
-		return errNoCommandsDefined
-	}
-
-	cmds := strings.Split(app.commands, "::")
-
-	i.Devices = map[string]*device{}
-
-	i.Devices[app.address] = &device{
-		Platform:     app.platform,
-		Address:      app.address,
-		SendCommands: cmds,
-	}
-
-	return nil
 }

--- a/commando/conn.go
+++ b/commando/conn.go
@@ -1,0 +1,163 @@
+package commando
+
+import (
+	"github.com/scrapli/scrapligo/driver/base"
+	"github.com/scrapli/scrapligo/driver/core"
+	"github.com/scrapli/scrapligo/driver/network"
+	"github.com/scrapli/scrapligo/transport"
+	log "github.com/sirupsen/logrus"
+	"github.com/srl-labs/srlinux-scrapli"
+)
+
+func (app *appCfg) validTransport(t string) bool {
+	switch t {
+	case transport.SystemTransportName:
+		return true
+	case transport.StandardTransportName:
+		return true
+	case transport.TelnetTransportName:
+		return true
+	default:
+		return false
+	}
+}
+
+func (app *appCfg) loadCredentials(o []base.Option, c string) ([]base.Option, error) {
+	creds, ok := app.credentials[c]
+	if !ok {
+		return o, errInvalidCredentialsName
+	}
+
+	if creds.Username != "" {
+		o = append(o, base.WithAuthUsername(creds.Username))
+	}
+
+	if creds.Password != "" {
+		o = append(o, base.WithAuthPassword(creds.Password))
+	}
+
+	if creds.SecondaryPassword != "" {
+		o = append(o, base.WithAuthSecondary(creds.SecondaryPassword))
+	}
+
+	if creds.PrivateKey != "" {
+		o = append(o, base.WithAuthPrivateKey(creds.PrivateKey))
+	}
+
+	return o, nil
+}
+
+func (app *appCfg) loadTransport(o []base.Option, t string) ([]base.Option, error) {
+	// default to strict key false and standard transport, so load those into options first
+	o = append(
+		o,
+		base.WithTransportType(transport.StandardTransportName),
+		base.WithAuthStrictKey(false),
+	)
+
+	transp, ok := app.transports[t]
+	if !ok {
+		if t == defaultName {
+			// default can not exist in the inventory, we already set the default settings above
+			return o, nil
+		}
+
+		return o, errInvalidTransportsName
+	}
+
+	if transp.Port != 0 {
+		o = append(o, base.WithPort(transp.Port))
+	}
+
+	if transp.StrictKey {
+		o = append(o, base.WithAuthStrictKey(transp.StrictKey))
+	}
+
+	if transp.SSHConfigFile != "" {
+		o = append(o, base.WithSSHConfigFile(transp.SSHConfigFile))
+	}
+
+	if transp.TransportType != "" {
+		if !app.validTransport(transp.TransportType) {
+			return nil, errInvalidTransport
+		}
+
+		o = append(o, base.WithTransportType(transp.TransportType))
+	}
+
+	return o, nil
+}
+
+// loadOptions loads options from the provided inventory.
+func (app *appCfg) loadOptions(d *device) ([]base.Option, error) {
+	var o []base.Option
+
+	var err error
+
+	c := defaultName
+
+	if d.Credentials != "" {
+		c = d.Credentials
+	}
+
+	o, err = app.loadCredentials(o, c)
+	if err != nil {
+		return o, err
+	}
+
+	t := defaultName
+
+	if d.Transport != "" {
+		t = d.Transport
+	}
+
+	o, err = app.loadTransport(o, t)
+	if err != nil {
+		return o, err
+	}
+
+	return o, err
+}
+
+func (app *appCfg) openCoreConn(name string, d *device) (*network.Driver, error) {
+	var driver *network.Driver
+
+	o, err := app.loadOptions(d)
+	if err != nil {
+		log.Errorf(
+			"failed to load credentials or transport options for %s; error: %+v\n",
+			name,
+			err,
+		)
+
+		return nil, err
+	}
+
+	switch d.Platform {
+	case "nokia_srlinux":
+		driver, err = srlinux.NewSRLinuxDriver(
+			d.Address,
+			o...,
+		)
+	default:
+		driver, err = core.NewCoreDriver(
+			d.Address,
+			d.Platform,
+			o...,
+		)
+	}
+
+	if err != nil {
+		log.Errorf("failed to create driver for device %s; error: %+v\n", err, name)
+		return nil, err
+	}
+
+	err = driver.Open()
+	if err != nil {
+		log.Errorf("failed to open connection to device %s; error: %+v\n", err, name)
+
+		return nil, err
+	}
+
+	return driver, nil
+}

--- a/commando/inventory.go
+++ b/commando/inventory.go
@@ -1,0 +1,78 @@
+package commando
+
+import (
+	"io/ioutil"
+	"regexp"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
+)
+
+func (app *appCfg) loadInventoryFromYAML(i *inventory) error {
+	yamlFile, err := ioutil.ReadFile(app.inventory)
+	if err != nil {
+		return err
+	}
+
+	err = yaml.UnmarshalStrict(yamlFile, i)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	filterDevices(i, app.devFilter)
+
+	if len(i.Devices) == 0 {
+		return errNoDevices
+	}
+
+	app.credentials = i.Credentials
+	app.transports = i.Transports
+
+	return nil
+}
+
+func (app *appCfg) loadInventoryFromFlags(i *inventory) error {
+	if app.platform == "" {
+		return errNoPlatformDefined
+	}
+
+	if app.username == "" {
+		return errNoUsernameDefined
+	}
+
+	if app.password == "" {
+		return errNoPasswordDefined
+	}
+
+	if app.commands == "" {
+		return errNoCommandsDefined
+	}
+
+	cmds := strings.Split(app.commands, "::")
+
+	i.Devices = map[string]*device{}
+
+	i.Devices[app.address] = &device{
+		Platform:     app.platform,
+		Address:      app.address,
+		SendCommands: cmds,
+	}
+
+	return nil
+}
+
+// filterDevices will remove the devices which names do not match the passed filter.
+func filterDevices(i *inventory, f string) {
+	if f == "" {
+		return
+	}
+
+	fRe := regexp.MustCompile(f)
+
+	for n := range i.Devices {
+		if !fRe.Match([]byte(n)) {
+			delete(i.Devices, n)
+		}
+	}
+}

--- a/commando/respwriter.go
+++ b/commando/respwriter.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/scrapli/scrapligo/cfg"
+
 	"github.com/fatih/color"
 	"github.com/scrapli/scrapligo/driver/base"
 )
@@ -17,7 +19,7 @@ const (
 )
 
 type responseWriter interface {
-	WriteResponse(r []*base.MultiResponse, name string) error
+	WriteResponse(r []interface{}, name string) error
 }
 
 func (app *appCfg) newResponseWriter(f string) responseWriter {
@@ -45,32 +47,57 @@ type consoleWriter struct{}
 
 func (w *consoleWriter) writeFailure(name string) error {
 	c := color.New(color.FgRed)
-	c.Fprintf(os.Stderr, "\n**************************\n%s failed\n**************************\n", name)
+	c.Fprintf(
+		os.Stderr,
+		"\n**************************\n%s failed\n**************************\n",
+		name,
+	)
 
 	return nil
 }
 
-func (w *consoleWriter) writeSuccess(r []*base.MultiResponse, name string) error {
+func (w *consoleWriter) writeSuccess(r []interface{}, name string) error {
 	c := color.New(color.FgGreen)
 	c.Fprintf(os.Stderr, "\n**************************\n%s\n**************************\n", name)
 
 	for _, mr := range r {
-		for _, resp := range mr.Responses {
-			c := color.New(color.Bold)
-			c.Fprintf(os.Stderr, "\n-- %s:\n", resp.ChannelInput)
+		switch respObj := mr.(type) {
+		case *base.MultiResponse:
+			for _, resp := range respObj.Responses {
+				c := color.New(color.Bold)
+				c.Fprintf(os.Stderr, "\n-- %s:\n", resp.ChannelInput)
 
-			if resp.Failed {
+				if resp.Failed {
+					color.Set(color.FgRed)
+				}
+
+				fmt.Println(resp.Result)
+			}
+		case *cfg.Response:
+			c := color.New(color.Bold)
+			c.Fprintf(os.Stderr, "\n-- cfg-%s:\n", respObj.OperationType)
+
+			if respObj.Failed {
 				color.Set(color.FgRed)
 			}
 
-			fmt.Println(resp.Result)
+			fmt.Println(respObj.Result)
+		case *cfg.DiffResponse:
+			c := color.New(color.Bold)
+			c.Fprint(os.Stderr, "\n-- cfg-DiffConfig:\n")
+
+			if respObj.Failed {
+				color.Set(color.FgRed)
+			}
+
+			fmt.Println(respObj.DeviceDiff)
 		}
 	}
 
 	return nil
 }
 
-func (w *consoleWriter) WriteResponse(r []*base.MultiResponse, name string) error {
+func (w *consoleWriter) WriteResponse(r []interface{}, name string) error {
 	if r == nil {
 		return w.writeFailure(name)
 	}
@@ -83,20 +110,27 @@ type fileWriter struct {
 	dir string // output dir name
 }
 
-func (w *fileWriter) WriteResponse(r []*base.MultiResponse, name string) error {
+func (w *fileWriter) WriteResponse(r []interface{}, name string) error {
 	outDir := path.Join(w.dir, name)
 	if err := os.MkdirAll(outDir, filePermissions); err != nil {
 		return err
 	}
 
 	for _, mr := range r {
-		for _, resp := range mr.Responses {
-			c := sanitizeCmd(resp.ChannelInput)
+		switch respObj := mr.(type) {
+		case *base.MultiResponse:
+			for _, resp := range respObj.Responses {
+				c := sanitizeCmd(resp.ChannelInput)
 
-			rb := []byte(resp.Result)
-			if err := ioutil.WriteFile(path.Join(outDir, c), rb, filePermissions); err != nil {
-				return err
+				rb := []byte(resp.Result)
+				if err := ioutil.WriteFile(path.Join(outDir, c), rb, filePermissions); err != nil {
+					return err
+				}
 			}
+		case *cfg.Response:
+			fmt.Printf("GOT CFG RESPONSE, DUNNO HOW TO HANDLE YET!\n")
+		case *cfg.DiffResponse:
+			fmt.Printf("GOT DIFF RESPONSE, DUNNO HOW TO HANDLE YET!\n")
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,9 @@ module github.com/hellt/cmdo
 go 1.16
 
 require (
+	github.com/carlmontanari/difflibgo v0.0.0-20210718194309-31b9e131c298 // indirect
 	github.com/fatih/color v1.12.0
-	github.com/scrapli/scrapligo v0.0.0-20210704164516-6c3b4e74cfad
+	github.com/scrapli/scrapligo v0.0.0-20210821175721-39f27f3d8e89
 	github.com/sirupsen/logrus v1.8.1
 	github.com/srl-labs/srlinux-scrapli v0.0.0-20210601201111-9eed8d440381
 	github.com/urfave/cli/v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,7 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/carlmontanari/difflibgo v0.0.0-20210718170140-424f52054f94/go.mod h1:+3MuSIeC3qmdSesR12cTLeb47R/Vvo+bHdB6hC5HShk=
+github.com/carlmontanari/difflibgo v0.0.0-20210718194309-31b9e131c298 h1:Y8rTum6LZ8oP/2aC+OaaP76OCjHbunKMkim81mzNCH0=
+github.com/carlmontanari/difflibgo v0.0.0-20210718194309-31b9e131c298/go.mod h1:+3MuSIeC3qmdSesR12cTLeb47R/Vvo+bHdB6hC5HShk=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=
@@ -18,10 +21,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/scrapli/scrapligo v0.0.0-20210601185115-acff0f312680/go.mod h1:itZE+qsyMvCMnxccsxMX4ATFqVLDIG/Mw4po4msqwpo=
-github.com/scrapli/scrapligo v0.0.0-20210602192414-6dd77b8af3c2 h1:tUOvIzMIJa9pbqKWTWx2OJi8JxF5AwgUGGWkMkSughM=
-github.com/scrapli/scrapligo v0.0.0-20210602192414-6dd77b8af3c2/go.mod h1:itZE+qsyMvCMnxccsxMX4ATFqVLDIG/Mw4po4msqwpo=
-github.com/scrapli/scrapligo v0.0.0-20210704164516-6c3b4e74cfad h1:eb+6BSk5gTJ3rsQ1CfZGfMsoxvo7ZYwKlCTszU1CtJs=
-github.com/scrapli/scrapligo v0.0.0-20210704164516-6c3b4e74cfad/go.mod h1:+csimZHh80jQXjdDdHmAIKCwiXPZvXQ7ZgKEQWmFpK8=
+github.com/scrapli/scrapligo v0.0.0-20210821175721-39f27f3d8e89 h1:rug+AbhjrFqbkeFjfZz7wQ2X6yIeZOC9daso3p0xaic=
+github.com/scrapli/scrapligo v0.0.0-20210821175721-39f27f3d8e89/go.mod h1:0tHMgiCiTuWOvSceFU7klaYThXvRZNvc7k+fmQrtH54=
 github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirikothe/gotextfsm v1.0.0 h1:4kKwbUziG9G+31PfLY+vI3FzYK/kcByh4ndT3NyPMkc=

--- a/inventory.yml
+++ b/inventory.yml
@@ -31,12 +31,16 @@ devices:
     address: clab-scrapli-ceos
     credentials: eos
     transport: eos
+    send-commands-from-file: somefile.txt
     send-commands:
       - show version
       - show uptime
   srlinux:
     platform: nokia_srlinux
     address: clab-scrapli-srlinux
+    send-commands:
+      - /system information location "commando"
+      - commit now
     send-commands:
       - show version
       - show network-instance interfaces


### PR DESCRIPTION
this PR adds support for

* `send-commands-from-file`
* `send-configs`
* `send-configs-from-file`
device-level options


The idea is to allow pushing some config to the devices before scrpaligo has cfg support.

/cc @carlmontanari  