### PR TITLE
Fix Cfg Output

### DIFF
--- a/commando/respwriter.go
+++ b/commando/respwriter.go
@@ -8,10 +8,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/scrapli/scrapligo/driver/base"
+
 	"github.com/scrapli/scrapligo/cfg"
 
 	"github.com/fatih/color"
-	"github.com/scrapli/scrapligo/driver/base"
 )
 
 const (
@@ -67,7 +68,7 @@ func (w *consoleWriter) writeSuccess(r []interface{}, name string) error {
 				c := color.New(color.Bold)
 				c.Fprintf(os.Stderr, "\n-- %s:\n", resp.ChannelInput)
 
-				if resp.Failed {
+				if resp.Failed != nil {
 					color.Set(color.FgRed)
 				}
 
@@ -77,7 +78,7 @@ func (w *consoleWriter) writeSuccess(r []interface{}, name string) error {
 			c := color.New(color.Bold)
 			c.Fprintf(os.Stderr, "\n-- cfg-%s:\n", respObj.OperationType)
 
-			if respObj.Failed {
+			if respObj.Failed != nil {
 				color.Set(color.FgRed)
 			}
 
@@ -86,7 +87,7 @@ func (w *consoleWriter) writeSuccess(r []interface{}, name string) error {
 			c := color.New(color.Bold)
 			c.Fprint(os.Stderr, "\n-- cfg-DiffConfig:\n")
 
-			if respObj.Failed {
+			if respObj.Failed != nil {
 				color.Set(color.FgRed)
 			}
 
@@ -128,9 +129,18 @@ func (w *fileWriter) WriteResponse(r []interface{}, name string) error {
 				}
 			}
 		case *cfg.Response:
-			fmt.Printf("GOT CFG RESPONSE, DUNNO HOW TO HANDLE YET!\n")
+			rb := []byte(respObj.Result)
+			if err := ioutil.WriteFile(path.Join(outDir, respObj.OperationType), rb, filePermissions); err != nil {
+				return err
+			}
 		case *cfg.DiffResponse:
-			fmt.Printf("GOT DIFF RESPONSE, DUNNO HOW TO HANDLE YET!\n")
+			rb := []byte(
+				fmt.Sprintf("Device Diff:\n%s\n\nSide By Side Diff:\n%s\n\nUnified Diff:\n%s",
+					respObj.DeviceDiff, respObj.SideBySideDiff(), respObj.UnifiedDiff()),
+			)
+			if err := ioutil.WriteFile(path.Join(outDir, respObj.OperationType), rb, filePermissions); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/carlmontanari/difflibgo v0.0.0-20210718194309-31b9e131c298 // indirect
 	github.com/fatih/color v1.12.0
-	github.com/scrapli/scrapligo v0.0.0-20210828223731-aa2b82d0b593
+	github.com/scrapli/scrapligo v0.1.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/srl-labs/srlinux-scrapli v0.0.0-20210601201111-9eed8d440381
 	github.com/urfave/cli/v2 v2.3.0

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/carlmontanari/difflibgo v0.0.0-20210718194309-31b9e131c298 // indirect
 	github.com/fatih/color v1.12.0
-	github.com/scrapli/scrapligo v0.0.0-20210821175721-39f27f3d8e89
+	github.com/scrapli/scrapligo v0.0.0-20210828223731-aa2b82d0b593
 	github.com/sirupsen/logrus v1.8.1
 	github.com/srl-labs/srlinux-scrapli v0.0.0-20210601201111-9eed8d440381
 	github.com/urfave/cli/v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/scrapli/scrapligo v0.0.0-20210601185115-acff0f312680/go.mod h1:itZE+qsyMvCMnxccsxMX4ATFqVLDIG/Mw4po4msqwpo=
-github.com/scrapli/scrapligo v0.0.0-20210821175721-39f27f3d8e89 h1:rug+AbhjrFqbkeFjfZz7wQ2X6yIeZOC9daso3p0xaic=
-github.com/scrapli/scrapligo v0.0.0-20210821175721-39f27f3d8e89/go.mod h1:0tHMgiCiTuWOvSceFU7klaYThXvRZNvc7k+fmQrtH54=
+github.com/scrapli/scrapligo v0.0.0-20210828223731-aa2b82d0b593 h1:JAe+I0cjTpk4CIIWaFO5NaLIFkEuVsywlh4Yb9gzcnM=
+github.com/scrapli/scrapligo v0.0.0-20210828223731-aa2b82d0b593/go.mod h1:0tHMgiCiTuWOvSceFU7klaYThXvRZNvc7k+fmQrtH54=
 github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirikothe/gotextfsm v1.0.0 h1:4kKwbUziG9G+31PfLY+vI3FzYK/kcByh4ndT3NyPMkc=

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/scrapli/scrapligo v0.0.0-20210601185115-acff0f312680/go.mod h1:itZE+qsyMvCMnxccsxMX4ATFqVLDIG/Mw4po4msqwpo=
 github.com/scrapli/scrapligo v0.0.0-20210828223731-aa2b82d0b593 h1:JAe+I0cjTpk4CIIWaFO5NaLIFkEuVsywlh4Yb9gzcnM=
 github.com/scrapli/scrapligo v0.0.0-20210828223731-aa2b82d0b593/go.mod h1:0tHMgiCiTuWOvSceFU7klaYThXvRZNvc7k+fmQrtH54=
+github.com/scrapli/scrapligo v0.1.0 h1:6bAtdQY9Phnacy811lf8kgoWqIMYAM/E3b5N07wVbyU=
+github.com/scrapli/scrapligo v0.1.0/go.mod h1:0tHMgiCiTuWOvSceFU7klaYThXvRZNvc7k+fmQrtH54=
 github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirikothe/gotextfsm v1.0.0 h1:4kKwbUziG9G+31PfLY+vI3FzYK/kcByh4ndT3NyPMkc=


### PR DESCRIPTION
- bumps pin for scrapli -> current dev branch that we've been discussing for the kne bits
- updates the `Failed` bits to the new setup where failed is an error instead of a bool
- actually write out cfg results (tested it and its pretty slick!)

draft since will probably just update pin to master (and maybe even make a real scrapligo release?!?!?) after things are dialed in on the kne side of things!