### PR TITLE
pin to 0.1.1 to handle secondary auth better!

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/carlmontanari/difflibgo v0.0.0-20210718194309-31b9e131c298 // indirect
 	github.com/fatih/color v1.12.0
-	github.com/scrapli/scrapligo v0.1.0
+	github.com/scrapli/scrapligo v0.1.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/srl-labs/srlinux-scrapli v0.0.0-20210601201111-9eed8d440381
 	github.com/urfave/cli/v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -21,10 +21,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/scrapli/scrapligo v0.0.0-20210601185115-acff0f312680/go.mod h1:itZE+qsyMvCMnxccsxMX4ATFqVLDIG/Mw4po4msqwpo=
-github.com/scrapli/scrapligo v0.0.0-20210828223731-aa2b82d0b593 h1:JAe+I0cjTpk4CIIWaFO5NaLIFkEuVsywlh4Yb9gzcnM=
-github.com/scrapli/scrapligo v0.0.0-20210828223731-aa2b82d0b593/go.mod h1:0tHMgiCiTuWOvSceFU7klaYThXvRZNvc7k+fmQrtH54=
-github.com/scrapli/scrapligo v0.1.0 h1:6bAtdQY9Phnacy811lf8kgoWqIMYAM/E3b5N07wVbyU=
-github.com/scrapli/scrapligo v0.1.0/go.mod h1:0tHMgiCiTuWOvSceFU7klaYThXvRZNvc7k+fmQrtH54=
+github.com/scrapli/scrapligo v0.1.1 h1:kSRgH81a4Ec0qM3VK1AHp3/C0mvPclVteQMaW7vTXS0=
+github.com/scrapli/scrapligo v0.1.1/go.mod h1:0tHMgiCiTuWOvSceFU7klaYThXvRZNvc7k+fmQrtH54=
 github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirikothe/gotextfsm v1.0.0 h1:4kKwbUziG9G+31PfLY+vI3FzYK/kcByh4ndT3NyPMkc=


### PR DESCRIPTION
0.1.1 makes secondary auth handling much better -- w/ 0.1.0 if a device does *not* have a secondary (enable) password, we just sit there and hang waiting for a timeout then continue on like nothing happened. w/ 0.1.1 we "bail out" of the interactive prompt handling if we see a prompt come back from the device -- much smarter/faster!