### PR TITLE
fix yaml parser

### DIFF
--- a/commando/cmdo.go
+++ b/commando/cmdo.go
@@ -80,7 +80,7 @@ type transports struct {
 	Port          int    `yaml:"port,omitempty"`
 	StrictKey     bool   `yaml:"strict-key,omitempty"`
 	SSHConfigFile string `yaml:"ssh-config-file,omitempty"`
-	TransportType string `yaml:"transport,omitempty"`
+	TransportType string `yaml:"transport-type,omitempty"`
 }
 
 type cfgOperation struct {


### PR DESCRIPTION
Noticed that the `transport-type` field in transports option failed to parse.