### PR TITLE
Add feature to append any commands to original commands.

### DIFF
--- a/commando/inventory.go
+++ b/commando/inventory.go
@@ -32,7 +32,7 @@ func (app *appCfg) loadInventoryFromYAML(i *inventory) error {
 	cmds := strings.Split(app.commands, "::")
 
 	for _, device := range i.Devices {
-		device.SendCommands = append(device.SendCommands, cmds...)
+		device.SendCommands = cmds
 	}
 
 	return nil

--- a/commando/inventory.go
+++ b/commando/inventory.go
@@ -29,6 +29,12 @@ func (app *appCfg) loadInventoryFromYAML(i *inventory) error {
 	app.credentials = i.Credentials
 	app.transports = i.Transports
 
+	cmds := strings.Split(app.commands, "::")
+
+	for _, device := range i.Devices {
+		device.SendCommands = append(device.SendCommands, cmds...)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
I think it is convenient to run commands add hoc against the devices defined in the inventory without editing the original inventory file everytime. If this pull-req does not match your design concept, feel free to reject it.

```sh
$ cmdo -i inventory.yml -c 'show interface description'
$ cmdo -i inventory.yml -c 'show interface description | include Gi'
```