### PR TITLE
fix: fix borked concurrency bits

### DIFF
--- a/commando/cmdo.go
+++ b/commando/cmdo.go
@@ -130,7 +130,9 @@ func (app *appCfg) run() error {
 	}
 
 	rw := app.newResponseWriter(app.output)
-	rCh := make(chan respTuple)
+
+	respCh := make(chan respTuple)
+
 	doneCh := make(chan interface{})
 
 	if app.output == fileOutput {
@@ -142,10 +144,10 @@ func (app *appCfg) run() error {
 	wg.Add(len(i.Devices))
 
 	for n, d := range i.Devices {
-		go app.runOperations(n, d, rCh)
+		go app.runOperations(n, d, respCh)
 	}
 
-	go app.outputResult(wg, rw, rCh, doneCh)
+	go app.outputResult(wg, rw, respCh, doneCh)
 
 	wg.Wait()
 

--- a/commando/cmdo.go
+++ b/commando/cmdo.go
@@ -110,6 +110,11 @@ type appCfg struct {
 	commands    string                  // commands to send
 }
 
+type respTuple struct {
+	name string
+	resp []interface{}
+}
+
 // run runs the commando.
 func (app *appCfg) run() error {
 	i := &inventory{}
@@ -125,7 +130,8 @@ func (app *appCfg) run() error {
 	}
 
 	rw := app.newResponseWriter(app.output)
-	rCh := make(chan []interface{})
+	rCh := make(chan respTuple)
+	doneCh := make(chan interface{})
 
 	if app.output == fileOutput {
 		log.SetOutput(os.Stderr)
@@ -137,12 +143,13 @@ func (app *appCfg) run() error {
 
 	for n, d := range i.Devices {
 		go app.runOperations(n, d, rCh)
-
-		resps := <-rCh
-		go app.outputResult(wg, rw, n, resps)
 	}
 
+	go app.outputResult(wg, rw, rCh, doneCh)
+
 	wg.Wait()
+
+	doneCh <- nil
 
 	if app.output == fileOutput {
 		log.Infof("outputs have been saved to '%s' directory", app.outDir)
@@ -321,10 +328,13 @@ func runCommands(name string, d *device, driver *network.Driver) ([]interface{},
 func (app *appCfg) runOperations(
 	name string,
 	d *device,
-	rCh chan<- []interface{}) {
+	rCh chan<- respTuple) {
 	driver, err := app.openCoreConn(name, d)
 	if err != nil {
-		rCh <- nil
+		rCh <- respTuple{
+			name: name,
+			resp: nil,
+		}
 
 		return
 	}
@@ -333,7 +343,10 @@ func (app *appCfg) runOperations(
 
 	cfgResponses, err := runCfg(name, d, driver)
 	if err != nil {
-		rCh <- nil
+		rCh <- respTuple{
+			name: name,
+			resp: nil,
+		}
 
 		return
 	}
@@ -342,31 +355,52 @@ func (app *appCfg) runOperations(
 
 	err = runConfigs(name, d, driver)
 	if err != nil {
-		rCh <- nil
+		rCh <- respTuple{
+			name: name,
+			resp: nil,
+		}
 
 		return
 	}
 
 	cmdResponses, err := runCommands(name, d, driver)
 	if err != nil {
-		rCh <- nil
+		rCh <- respTuple{
+			name: name,
+			resp: nil,
+		}
 
 		return
 	}
 
 	responses = append(responses, cmdResponses...)
 
-	rCh <- responses
+	rCh <- respTuple{
+		name: name,
+		resp: responses,
+	}
 }
 
 func (app *appCfg) outputResult(
 	wg *sync.WaitGroup,
 	rw responseWriter,
-	name string,
-	r []interface{}) {
-	defer wg.Done()
+	rCh chan respTuple,
+	doneCh chan interface{},
+) {
+	for {
+		select {
+		case <-doneCh:
+			return
+		case r := <-rCh:
+			if err := rw.WriteResponse(r.resp, r.name); err != nil {
+				log.Errorf("error while writing the response: %v", err)
 
-	if err := rw.WriteResponse(r, name); err != nil {
-		log.Errorf("error while writing the response: %v", err)
+				// don't defer the wg.Done because it needs to always be decremented at each
+				// iteration!
+				wg.Done()
+			} else {
+				wg.Done()
+			}
+		}
 	}
 }

--- a/go.sum
+++ b/go.sum
@@ -31,10 +31,6 @@ github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTE
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/scrapli/scrapligo v1.0.0/go.mod h1:jvRMdb90MNnswMiku8UNXj8JZaOIPhwhcqqFwr9qeoY=
-github.com/scrapli/scrapligo v1.0.2 h1:IzZPtfuuINvewd72Jjt91fr43s3y1shI4rXWnKmpC7A=
-github.com/scrapli/scrapligo v1.0.2/go.mod h1:jvRMdb90MNnswMiku8UNXj8JZaOIPhwhcqqFwr9qeoY=
-github.com/scrapli/scrapligo v1.0.3 h1:nLqW1FquCG//l8lzPS9rGIMX/9fe8v9dJoupnem3Hdc=
-github.com/scrapli/scrapligo v1.0.3/go.mod h1:jvRMdb90MNnswMiku8UNXj8JZaOIPhwhcqqFwr9qeoY=
 github.com/scrapli/scrapligo v1.1.0 h1:KjCam57kIV2rlxAQg/J1G7v/xgRHvpJF+Gjz+LXhQaI=
 github.com/scrapli/scrapligo v1.1.0/go.mod h1:jvRMdb90MNnswMiku8UNXj8JZaOIPhwhcqqFwr9qeoY=
 github.com/scrapli/scrapligocfg v1.0.0 h1:540SuGqqM6rKN87SLCfR54IageQ6s3a/ZOycGRgbbak=


### PR DESCRIPTION
@glspi is maybe testing this a bit more, but we realized we were uh... not very concurrent 🤣 

tldr;  the `resp := <- rCh` was blocking on each device waiting for response. so just moved things around a bit and created a dummy object to send into channel so we can always have the device name bound to response even if things fail early (as in no scrapligo response object gets created because we send nil to the rCh).